### PR TITLE
fix generic questionnaire

### DIFF
--- a/input/questionnaire-generic.json
+++ b/input/questionnaire-generic.json
@@ -69,11 +69,11 @@
                             }
                         },
                         {
-                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-lowRangeLabel",
+                            "url": "https://num-compass.science/fhir/StructureDefinition/LowRangeLabel",
                             "valueString": "Niedrig"
                         },
                         {
-                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-highRangeLabel",
+                            "url": "https://num-compass.science/fhir/StructureDefinition/HighRangeLabel",
                             "valueString": "Hoch"
                         },
                         {


### PR DESCRIPTION
According to [this profile](https://github.com/NUMde/compass-implementation-guide/blob/bc9f8a1b99e54ecfdc0c849d8849c65dc8ee7af1/input/fsh/fhirquestionnaire.fsh) the labels for the slider in the generic questionnaire are wrong.

This pull request fixes them